### PR TITLE
Add CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,24 @@ himawari({
 
 ```
 
+### Command line interface
+
+There is also a command-line interface available if you install it with `-g`.
+
+```sh
+npm i -g himawari
+```
+
+This installs a program called `himawari` that can be used like so:
+
+```
+Usage: himawari [options]
+    --zoom, -z            The zoom level of the image. Can be 1-4. (default: 1)
+    --date, -d            The time of the picture desired. If you want to get the latest image, use 'latest'. (default: "latest")
+    --outfile, -o         The location to save the resulting image. (default: "himawari-{date}.jpg" in current directory)
+    --help, -h            show help
+```
+
 ### Acknowledgement
 [Michael Pote](https://github.com/MichaelPote) created a [Powershell Script](https://gist.github.com/MichaelPote/92fa6e65eacf26219022) that inspired this library.
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+
+var himawari = require('../');
+var path = require('path');
+var cliclopts = require('cliclopts');
+var minimist = require('minimist');
+
+var allowedOptions = [
+  {
+    name: 'zoom',
+    abbr: 'z',
+    help: 'The zoom level of the image. Can be 1-4.',
+    default: 1
+  },
+  {
+    name: 'date',
+    abbr: 'd',
+    help: 'The time of the picture desired. If you want to get the latest image, use "latest".',
+    default: 'latest'
+  },
+  {
+    name: 'outfile',
+    abbr: 'o',
+    help: 'The location to save the resulting image. (default: "himawari-{date}.jpg" in current directory)'
+  },
+  {
+    name: 'help',
+    abbr: 'h',
+    help: 'show help',
+    boolean: true
+  }
+];
+
+var opts = cliclopts(allowedOptions);
+var argv = minimist(process.argv.slice(2), opts.options());
+
+if (argv.help) {
+  console.log('Usage: himawari [options]');
+  opts.print();
+  process.exit();
+}
+
+var basename;
+var dirname;
+var outfile;
+
+if (argv.outfile) {
+  outfile = path.normalize(argv.outfile);
+  basename = path.basename(outfile);
+  dirname = path.dirname(outfile);
+} else {
+  basename = 'himawari' + '-' + argv.date + '.jpg';
+  dirname = process.cwd();
+  outfile = path.join(dirname, basename);
+}
+
+console.log('Creating ' + basename + ' in ' + dirname + ' ...');
+
+himawari({
+  zoom: argv.zoom || 1,
+  outfile: outfile,
+  date: argv.date || 'latest',
+  success: function () {
+    console.log('Complete!');
+    process.exit();
+  },
+  error: function (err) {
+    console.log(err);
+    process.exit(1);
+  },
+  chunk: function (info) {
+    console.log('Saved', info.part + '/' + info.total);
+  }
+});

--- a/package.json
+++ b/package.json
@@ -8,9 +8,14 @@
   "license": "MIT",
   "dependencies": {
     "async": "^1.5.2",
+    "cliclopts": "^1.1.1",
     "gm": "^1.21.1",
+    "minimist": "^1.2.0",
     "moment": "^2.11.2",
     "request": "^2.69.0",
     "rimraf": "^2.5.1"
+  },
+  "bin": {
+    "himawari": "./bin/cli.js"
   }
 }


### PR DESCRIPTION
Awesome module! I added a command line interface so you can do something like:

``` sh
$ npm i -g himawari
$ himawari --help

Usage: himawari [options]
    --zoom, -z            The zoom level of the image. Can be 1-4. (default: 1)
    --date, -d            The time of the picture desired. If you want to get the latest image, use "latest". (default: "latest")
    --outfile, -o         The location to save the resulting image. (default: "himawari-{date}.jpg" in current directory)
    --help, -h            show help

$ himawari -o ~/Desktop/earth-latest.jpg

Creating earth-latest.jpg in /Users/ng/Desktop ...
Saved 1/16
Saved 2/16
Saved 3/16
Saved 4/16
Saved 5/16
Saved 6/16
Saved 7/16
Saved 8/16
Saved 9/16
Saved 10/16
Saved 11/16
Saved 12/16
Saved 13/16
Saved 14/16
Saved 15/16
Saved 16/16
Complete!
```

Please let me know if you're open to adding this to your module and if you want me to make any changes to the interface.

If you prefer I can also publish this as a separate module (e.g. `himawari-cli`).
