### PR TITLE
add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+demo
+example.js


### PR DESCRIPTION
This PR adds a `.npmignore` file that ignores the `demo` folder and `example.js` file so that they are not unnecessarily installed in `npm install` distributions.
