### PR TITLE
Use unique temp directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "minimist": "^1.2.0",
     "moment": "^2.11.2",
     "request": "^2.69.0",
-    "rimraf": "^2.5.1"
+    "tmp": "^0.0.28"
   },
   "bin": {
     "himawari": "./bin/cli.js"


### PR DESCRIPTION
Currently, a hardcoded temporary directory is used. This leads to race conditions if multiple `himawari` requests are running concurrently.
