### PR TITLE
fix hint errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ module.exports = function (userOptions) {
     }
 
     // Create a temp directory
-    var tmp = mktemp.dirSync({unsafeCleanup: true})
+    var tmp = mktemp.dirSync({unsafeCleanup: true});
 
     // Execute requests
     var count = 1;
@@ -187,7 +187,7 @@ module.exports = function (userOptions) {
 
         // Clean
         log('Cleaning temp files...');
-        tmp.removeCallback()
+        tmp.removeCallback();
         return options.success('File saved to ' + outfile);
       });
     });

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "repository": "https://github.com/jakiestfu/himawari.js.git",
   "scripts": {
-    "hint": "./node_modules/jshint/bin/jshint index.js bin/cli.js",
+    "hint": "jshint index.js bin/cli.js",
     "deploy": "git push -f origin master:gh-pages"
   },
   "author": "Jacob Kelley <jakie8@gmail.com>",


### PR DESCRIPTION
This PR fixes two minor hint errors and simplifies the `hint` package.json script.

> protip: package.json scripts will look for executables in `./node_modules/.bin/` by default

I was originally trying to see how easy it would be to swap out your URL fetching logic and replace it with [`himawari-urls`](https://github.com/ngoldman/himawari-urls) -- turns out it's more complicated than I thought.

@jakiestfu let me know if you'd like commit access on `himawari-urls` since it's based on your work and was meant to provide a solution to #3. It's an [open open source](http://openopensource.org/) project :grin: 
