### PR TITLE
Error when omitting date paramter in CLI

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -59,7 +59,7 @@ if (argv.help) {
   opts.print();
   process.exit();
 }
-var date = moment.isDate(argv.date) ? argv.date : new Date(argv.date);
+var date = moment.isDate(argv.date) ? argv.date : new Date();
 var defaultBasename = 'himawari' + '-' + date.getTime() + '.jpg';
 var basename;
 var dirname;


### PR DESCRIPTION
Omitting the date option in the CLI was not working. More specifically filenames would include a 'NaN' instead of the date. I am on Ubuntu hence could not test this on any other platform.
I have no experience with node.js, so beware ;)
