### PR TITLE
ignore examples folder

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,2 @@
 demo
-example.js
+examples


### PR DESCRIPTION
This updates `.npmignore` to include the new `examples` directory.
