### PR TITLE
add timeout to latest.json request

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,14 @@ module.exports = function (userOptions) {
   var noop = function () {};
 
   log('Resolving date...');
-  resolveDate(base_url, options.date, function (now) {
+  resolveDate(base_url, options.date, function (err, now) {
+    if (err) {
+      if (err.code === 'ETIMEDOUT') {
+        return console.error('Request to Himawari 8 server timed out. Please try again later.');
+      } else {
+        return console.error(err);
+      }
+    }
 
     log('Date resolved', now.toString());
 
@@ -226,17 +233,22 @@ function resolveDate (base_url, input, callback) {
   }
 
   // If provided a date object
-  if (moment.isDate(date)) { return callback(date); }
+  if (moment.isDate(date)) { return callback(null, date); }
 
   // If provided "latest"
   else if (input === "latest") {
-    request(base_url + '/latest.json', function (err, res) {
+    request({
+      method: 'GET',
+      uri: base_url + '/latest.json',
+      timeout: 30000
+    }, function (err, res) {
+      if (err) return callback(err);
       try { date = new Date(JSON.parse(res.body).date); }
       catch (e) { date = new Date(); }
-      return callback(date);
+      return callback(null, date);
     });
   }
 
   // Invalid string provided, return new Date
-  else { return callback(new Date()); }
+  else { return callback(null, new Date()); }
 }


### PR DESCRIPTION
Calls to `latest.json` have been timing out for me a lot lately. This PR adds a timeout to the request and modifies the `resolveDate` function signature to provide an opportunity to catch the error.
