### PR TITLE
add newline for image to render in markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 > Download real-time images of Earth from the Himawari-8 satellite
 
 [![npm][npm-image]][npm-url]
+
 [npm-image]: https://img.shields.io/npm/v/himawari.svg?style=flat-square
 [npm-url]: https://www.npmjs.com/package/himawari
 


### PR DESCRIPTION
The version badge doesn't render properly on npm. See below:

![screen shot 2016-02-13 at 11 34 29 pm](https://cloud.githubusercontent.com/assets/427322/13032511/5f094174-d2aa-11e5-851c-6e24623ed6f4.png)

Adding a line break to separate the image tag from its references should do the trick.
