### PR TITLE
validate zoom levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,12 +113,12 @@ This installs a program called `himawari` that can be used like so:
 
 ```sh
 Usage: himawari [options]
-    --zoom, -z            The zoom level of the image. Can be 1-5. (Default: `1`)
-    --date, -d            The time of the picture desired. If you want to get the latest image, use 'latest'. (Default: `"latest"`)
-    --debug, -l           Turns on logging. (Default: `false`)
-    --outfile, -o         The location to save the resulting image. (Default: `"himawari-{date}.jpg"` in current directory)
-    --skipempty, -s       Skip saving images that contain no useful information (i.e. "No Image") (Default: `true`)
-    --infrared, -i        Capture picture on the infrared spectrum (Default: `false`)
+    --zoom, -z            The zoom level of the image. Can be 1-5 for visible light, 1-3 for infrared. (default: 1)
+    --date, -d            The time of the picture desired. If you want to get the latest image, use "latest". (default: "latest")
+    --debug, -l           Turns on logging (default: false)
+    --outfile, -o         The location to save the resulting image. (default: "himawari-{date}.jpg" in current directory)
+    --skipempty, -s       Don't download images that contain "No Image" (default: true)
+    --infrared, -i        Capture picture on the infrared spectrum (default: false)
     --help, -h            Show help
 ```
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -11,7 +11,7 @@ var allowedOptions = [
   {
     name: 'zoom',
     abbr: 'z',
-    help: 'The zoom level of the image. Can be 1-5.',
+    help: 'The zoom level of the image. Can be 1-5 for visible light, 1-3 for infrared.',
     default: 1
   },
   {
@@ -58,6 +58,19 @@ if (argv.help) {
   console.log('Usage: himawari [options]');
   opts.print();
   process.exit();
+}
+
+var validForVIS = 1 <= argv.zoom && argv.zoom <= 5;
+var validForIR = 1 <= argv.zoom && argv.zoom <= 3;
+
+if (argv.infrared && !validForIR) {
+  console.error('Invalid zoom for infrared: ' + argv.zoom + '. Must be 1-3.');
+  process.exit(1);
+}
+
+if (!argv.infrared && !validForVIS) {
+  console.error('Invalid zoom: ' + argv.zoom + '. Must be 1-5.');
+  process.exit(1);
 }
 
 var parsedDate = new Date(argv.date || new Date().toString());

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -24,7 +24,8 @@ var allowedOptions = [
     name: 'debug',
     abbr: 'l',
     help: 'Turns on logging',
-    boolean: true
+    boolean: true,
+    default: false
   },
   {
     name: 'outfile',
@@ -35,13 +36,15 @@ var allowedOptions = [
     name: 'skipempty',
     abbr: 's',
     help: 'Don\'t download images that contain "No Image"',
-    boolean: true
+    boolean: true,
+    default: true
   },
   {
     name: 'infrared',
     abbr: 'i',
     help: 'Capture picture on the infrared spectrum',
-    boolean: true
+    boolean: true,
+    default: false
   },
   {
     name: 'help',


### PR DESCRIPTION
This catches invalid zoom levels and exits the CLI with an informative error message.

```
$ ./bin/cli.js -z 0
Invalid zoom: 0. Must be 1-5.
$ ./bin/cli.js -z 6
Invalid zoom: 6. Must be 1-5.
$ ./bin/cli.js -z 4 -i
Invalid zoom for infrared: 4. Must be 1-3.
```

> fixes #20
