### PR TITLE
Added support for parallelization

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ himawari({
   outfile: '/path/to/output/earth.jpg',
 
   /**
+   * Set to true to parallelize tile downloads. Can be CPU intensive but decreases time to download images.
+   * @type {Boolean}
+   */
+  parallel: false,
+
+  /**
    * Skip empty images from being saved
    * @type {Boolean}
    */
@@ -117,6 +123,7 @@ Usage: himawari [options]
     --date, -d            The time of the picture desired. If you want to get the latest image, use 'latest'. (Default: `"latest"`)
     --debug, -l           Turns on logging. (Default: `false`)
     --outfile, -o         The location to save the resulting image. (Default: `"himawari-{date}.jpg"` in current directory)
+    --parallel, -p        Parallelize downloads for increased speeds (can be CPU intensive)
     --skipempty, -s       Skip saving images that contain no useful information (i.e. "No Image") (Default: `true`)
     --infrared, -i        Capture picture on the infrared spectrum (Default: `false`)
     --help, -h            Show help

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -32,6 +32,12 @@ var allowedOptions = [
     help: 'The location to save the resulting image. (default: "himawari-{date}.jpg" in current directory)'
   },
   {
+    name: 'parallel',
+    abbr: 'p',
+    help: 'Parallelize downloads for increased speeds (can be CPU intensive)',
+    boolean: true
+  },
+  {
     name: 'skipempty',
     abbr: 's',
     help: 'Don\'t download images that contain "No Image"',
@@ -92,6 +98,7 @@ himawari({
   date: argv.date,
   debug: argv.debug,
   infrared: argv.infrared,
+  parallel: argv.parallel,
   skipEmpty: argv.skipempty,
   success: function (info) {
     console.log('Complete', info);

--- a/index.js
+++ b/index.js
@@ -17,14 +17,16 @@ var emptyImages = {
   'b697574875d3b8eb5dd80e9b2bc9c749': 1
 };
 
-module.exports = function (userOptions) {
+var himawari = function (userOptions) {
 
   var options = extend({
     date: 'latest',
     debug: false,
     infrared: false,
     outfile: null,
+    parallel: false,
     skipEmpty: true,
+    timeout: 30000, // 30 seconds
     zoom: 1,
 
     success: function () {},
@@ -108,7 +110,8 @@ module.exports = function (userOptions) {
     // Execute requests
     var count = 1;
     var skipImage = false;
-    async.eachSeries(tiles, function (tile, cb) {
+    var flow = options.parallel ? 'each' : 'eachSeries';
+    async[flow](tiles, function (tile, cb) {
 
       if (skipImage) { return cb(); }
 
@@ -151,7 +154,7 @@ module.exports = function (userOptions) {
         request({
           method: 'GET',
           uri: uri,
-          timeout: 30000 // 30 Seconds
+          timeout: options.timeout // 30 Seconds
         })
         .on('response', function (res) {
           if (res.statusCode !== 200) {
@@ -236,7 +239,7 @@ function resolveDate (base_url, input, callback) {
   var date = input;
 
   // If provided a date string
-  if (typeof input == "string" && input !== "latest") {
+  if ((typeof input == "string" || typeof input == "number") && input !== "latest") {
     date = new Date(input);
   }
 
@@ -261,3 +264,6 @@ function resolveDate (base_url, input, callback) {
   // Invalid string provided, return new Date
   else { return callback(null, new Date()); }
 }
+
+himawari.resolveDate = resolveDate;
+module.exports = himawari;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "himawari",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Download real-time images of Earth from the Himawari-8 satellite",
   "main": "index.js",
   "repository": "https://github.com/jakiestfu/himawari.js.git",


### PR DESCRIPTION
There are definite gains by utilizing `async.each` as opposed to `async.eachSeries`.

``` sh
eachSeries  -> bin/cli.js -z 2 0.56s user 0.15s system 4% cpu 14.227 total
eachSeries  -> bin/cli.js -z 2 0.55s user 0.13s system 3% cpu 19.131 total
eachSeries  -> bin/cli.js -z 2 0.54s user 0.13s system 3% cpu 18.742 total
eachSeries Average: 17.367s

each        -> bin/cli.js -z 2 0.47s user 0.10s system 11% cpu 5.184 total
each        -> bin/cli.js -z 2 0.51s user 0.13s system 10% cpu 5.971 total
each        -> bin/cli.js -z 2 0.51s user 0.12s system 10% cpu 5.935 total
each Average: 5.69s
```
